### PR TITLE
Pass optional `fmt` on to stream formatter

### DIFF
--- a/src/sdsstools/logger.py
+++ b/src/sdsstools/logger.py
@@ -129,7 +129,12 @@ class SDSSLogger(logging.Logger):
 
         super(SDSSLogger, self).__init__(name)
 
-    def init(self, log_level: int = logging.INFO, capture_warnings: bool = True):
+    def init(
+        self, 
+        log_level: int = logging.INFO, 
+        capture_warnings: bool = True, 
+        fmt: Optional = None
+    ):
         """Initialise the logger.
 
         Parameters
@@ -138,6 +143,8 @@ class SDSSLogger(logging.Logger):
             The initial logging level for the console handler.
         capture_warnings
             Whether to capture warnings and redirect them to the log.
+        fmt
+            The message format to supply to the stream formatter.
         """
 
         # Set levels
@@ -145,7 +152,11 @@ class SDSSLogger(logging.Logger):
 
         # Sets the console handler
         self.sh = logging.StreamHandler()
-        self.sh.setFormatter(StreamFormatter())
+        if fmt is not None:
+            formatter = StreamFormatter(fmt)
+        else:
+            formatter = StreamFormatter()
+        self.sh.setFormatter(formatter)
         self.addHandler(self.sh)
         self.sh.setLevel(log_level)
 


### PR DESCRIPTION
I use the logger from `sdsstools`. I use a config file to set the log level when the logger is initialised.

I'd also like to set the format of the logging messages from the same config file. The keyword I (think I) need to set is `fmt` for `StreamFormatter`. But that doesn't get propagated from the logger class initialisation function. This PR changes that, and keeps the existing default behaviour.