### PR TITLE
Adds options for the TimedRotatingFileHandler

### DIFF
--- a/src/sdsstools/logger.py
+++ b/src/sdsstools/logger.py
@@ -319,6 +319,9 @@ class SDSSLogger(logging.Logger):
         mode: str = "a",
         rotating: bool = True,
         rollover: bool = False,
+        when: str = 'midnight',
+        utc: bool = True,
+        at_time: Union[str, datetime.time] = None,
     ):
         """Start file logging.
 
@@ -336,6 +339,14 @@ class SDSSLogger(logging.Logger):
         rollover
             If `True` and ``rotating=True` and the log file already exists, does a
             rollover before starting to log.
+        when
+            The type of time interval.  Allowed values are those from
+            `TimedRotatingFileHandler`.
+        utc
+            If `True`, times in UTC will be used; otherwise local time is used.
+        at_time
+            The time of day when rollover occurs, when rollover is set to occur
+            at “midnight” or “on a particular weekday”.
         """
 
         log_file_path = os.path.realpath(os.path.expanduser(path))
@@ -352,15 +363,19 @@ class SDSSLogger(logging.Logger):
                 dst = str(log_file_path) + "." + now.strftime(SUFFIX)
                 shutil.move(str(log_file_path), dst)
 
+            # convert at_time to a datetime.time
+            if at_time and isinstance(at_time, str):
+                at_time = datetime.time.fromisoformat(at_time)
+
             if rotating:
                 self.fh = TimedRotatingFileHandler(
-                    str(log_file_path), when="midnight", utc=True
+                    str(log_file_path), when=when, utc=utc, atTime=at_time
                 )
                 self.fh.suffix = SUFFIX  # type: ignore
             else:
                 self.fh = logging.FileHandler(str(log_file_path), mode=mode)
 
-        except (IOError, OSError) as ee:
+        except (IOError, OSError, ValueError) as ee:
             warnings.warn(
                 "log file {0!r} could not be opened for "
                 "writing: {1}".format(log_file_path, ee),

--- a/src/sdsstools/logger.py
+++ b/src/sdsstools/logger.py
@@ -319,7 +319,7 @@ class SDSSLogger(logging.Logger):
         mode: str = "a",
         rotating: bool = True,
         rollover: bool = False,
-        when: str = 'midnight',
+        when: str = "midnight",
         utc: bool = True,
         at_time: Union[str, datetime.time] = None,
     ):

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -187,7 +187,7 @@ def test_logger_when_options(tmp_path):
     logger1.start_file_logger(log_file, utc=False, when="M")
 
     assert logger1.fh.when == "M"
-    assert logger1.fh.utc == False
+    assert logger1.fh.utc is False
 
 
 def test_rich_handler_logger(caplog):

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -180,6 +180,16 @@ def test_logger_rotating_rollover(tmp_path):
     assert len(list((tmp_path / "logs").glob("*"))) == 2
 
 
+def test_logger_when_options(tmp_path):
+    log_file = tmp_path / "logs" / "test_log.log"
+
+    logger1 = get_logger(str(uuid.uuid4()))
+    logger1.start_file_logger(log_file, utc=False, when="M")
+
+    assert logger1.fh.when == "M"
+    assert logger1.fh.utc == False
+
+
 def test_rich_handler_logger(caplog):
     log = get_logger("test", use_rich_handler=True)
 


### PR DESCRIPTION
This PR adds options to `start_file_logger` for the `TimedRotatingFileHandler`.  It makes `when` an explicit option, and adds `utc` and `atTime` as options as well, as described [here](https://docs.python.org/3.8/library/logging.handlers.html#logging.handlers.TimedRotatingFileHandler). 