### PR TITLE
Dicts returned by RecursiveDict are instances of RecursiveDict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next version
 
-- If `RecursiveDict` or `Configuration` return a dictionary, the dictionary is itself a `RecursiveDict` or `Configuration` object.
+- [#44](https://github.com/sdss/sdsstools/issues/44) If `RecursiveDict` or `Configuration` return a dictionary, the dictionary is itself a `RecursiveDict` or `Configuration` object.
 
 
 ## [1.4.0](https://github.com/sdss/sdsstools/compare/1.3.2...1.4.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Next version
+
+- If `RecursiveDict` or `Configuration` return a dictionary, the dictionary is itself a `RecursiveDict` or `Configuration` object.
+
+
 ## [1.4.0](https://github.com/sdss/sdsstools/compare/1.3.2...1.4.0)
 
 - Add support for outputting log file in JSON format, via new options in `start_file_logger`.

--- a/src/sdsstools/configuration.py
+++ b/src/sdsstools/configuration.py
@@ -214,7 +214,7 @@ class RecursiveDict(Dict[str, Any]):
 
     def get(self, __key: str, default: Any = None, strict: bool | None = None) -> Any:
         if (strict is None and self.strict_mode is True) or strict is True:
-            return super().get(__key, default)
+            return dict.get(self, __key, default)
 
         current = dict(self)
         for item in __key.split("."):
@@ -222,6 +222,10 @@ class RecursiveDict(Dict[str, Any]):
                 current = current.get(item, default)
             else:
                 return default
+
+        if isinstance(current, dict):
+            current = self.__class__(current, strict_mode=self.strict_mode)
+
         return current
 
 

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -339,6 +339,10 @@ def test_configuration_recursive_getitem_strict():
     with pytest.raises(KeyError):
         conf["cat1.key2"]
 
+    conf.strict_mode = False
+
+    assert conf.get("cat1.key1", strict=True) is None
+
 
 def test_configuration_recursive_get():
     config = {"cat1": {"key1": 1}}
@@ -348,3 +352,11 @@ def test_configuration_recursive_get():
     assert conf.get("cat1.key2") is None
     assert conf.get("cat1.key2", default=-1) == -1
     assert conf.get("cat1.key1.a1", default=-1) == -1
+
+
+def test_configuration_recursive_inherits():
+    config = {"cat1": {"key1": 1}}
+    conf = Configuration(base_config=config)
+
+    assert isinstance(conf["cat1"], Configuration)
+    assert isinstance(conf["cat1.key1"], int)


### PR DESCRIPTION
Modification to `RecursiveDict.get()` so that if the method returns a dict, this gets converted into the recursive dict class (`Configuration` instance would return a `Configuration` dict).